### PR TITLE
Blind:set_text crash fix with other mods with "blind:artist" variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,5 +43,6 @@ If another mod depends on Bakery, but you do not want Bakery's additions, you ca
 - GhostSalt (@ghost12salt) and SadCube (@sadcube) - Some of the artwork used
 - [Jack5](https://github.com/jack5github) (@jack5) - Some ideas, coding and artwork
 - [balt](https://github.com/balt-dev) (@baltdev) - Bugfixes
+- [KassLavender](https://github.com/KassLavender) - Bugfixes
 
 > @ handles are for Discord.

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
     "badge_colour": "EDD198",
     "badge_text_colour": "362708",
     "display_name": "Bakery",
-    "version": "2.20.4",
+    "version": "2.20.5",
     "dependencies": [
         "Steamodded (>=1.0.0~BETA-0711a)",
         "Lovely (>=0.6)"

--- a/src/util.lua
+++ b/src/util.lua
@@ -793,19 +793,21 @@ Bakery_API.guard(function()
         local txt = ret.nodes[2].nodes[1].nodes[4]
         if txt and (blind.artist or blind.coder or blind.idea) then
             local function make(kind, contrib)
-                txt.nodes[#txt.nodes + 1] =
+                if contrib.name then
+                    txt.nodes[#txt.nodes + 1] =
                 { n = G.UIT.R, config = { align = "cm" }, colour = contrib.bg, nodes = { { n = G.UIT.T, config = { text = localize { type = 'variable', key = kind, vars = { contrib.name } }, scale = 0.2, shadow = true, colour = contrib.fg } } } }
+                end
             end
-            if blind.artist == blind.coder and blind.coder == blind.idea then
+            if blind.artist == blind.coder and blind.coder == blind.idea and Bakery_API.contributors[blind.artist] then
                 make("v_Bakery_by", Bakery_API.contributors[blind.artist])
             else
-                if blind.artist then
+                if blind.artist and Bakery_API.contributors[blind.artist] then
                     make("v_Bakery_artist", Bakery_API.contributors[blind.artist])
                 end
-                if blind.coder then
+                if blind.coder and Bakery_API.contributors[blind.coder]then
                     make("v_Bakery_coder", Bakery_API.contributors[blind.coder])
                 end
-                if blind.idea then
+                if blind.idea and Bakery_API.contributors[blind.idea] then
                     make("v_Bakery_idea", Bakery_API.contributors[blind.idea])
                 end
             end

--- a/src/util.lua
+++ b/src/util.lua
@@ -720,19 +720,16 @@ Bakery_API.guard(function()
 
     local raw_SMODS_calculate_repetitions = SMODS.calculate_repetitions
     SMODS.calculate_repetitions = function(card, context, reps, ...)
-        reps = raw_SMODS_calculate_repetitions(card, context, reps, ...)
-
         for i = 1, #G.GAME.tags do
             local eval = G.GAME.tags[i]:apply_to_run({
                 type = 'Bakery_add_repetitions_to_card',
                 context = context
             })
             if eval then
-                SMODS.insert_repetitions(reps, eval, G.GAME.tags[i])
+                reps[#reps + 1] = { key = eval }
             end
         end
-
-        return reps
+        return raw_SMODS_calculate_repetitions(card, context, reps, ...)
     end
 
     sendInfoMessage("SMODS.calculate_repetitions() patched. Reason: Up Tag", "Bakery")

--- a/src/util.lua
+++ b/src/util.lua
@@ -793,10 +793,8 @@ Bakery_API.guard(function()
         local txt = ret.nodes[2].nodes[1].nodes[4]
         if txt and (blind.artist or blind.coder or blind.idea) then
             local function make(kind, contrib)
-                if contrib.name then
-                    txt.nodes[#txt.nodes + 1] =
+                txt.nodes[#txt.nodes + 1] =
                 { n = G.UIT.R, config = { align = "cm" }, colour = contrib.bg, nodes = { { n = G.UIT.T, config = { text = localize { type = 'variable', key = kind, vars = { contrib.name } }, scale = 0.2, shadow = true, colour = contrib.fg } } } }
-                end
             end
             if blind.artist == blind.coder and blind.coder == blind.idea and Bakery_API.contributors[blind.artist] then
                 make("v_Bakery_by", Bakery_API.contributors[blind.artist])

--- a/src/util.lua
+++ b/src/util.lua
@@ -744,37 +744,45 @@ Bakery_API.guard(function()
         if blind and (blind.artist or blind.coder or blind.idea) then
             self.loc_debuff_lines[#self.loc_debuff_lines + 1] = ""
             if blind.artist == blind.coder and blind.coder == blind.idea then
-                local creator = Bakery_API.contributors[blind.artist]
-                self.loc_debuff_lines[#self.loc_debuff_lines + 1] = localize {
-                    type = 'variable',
-                    key = 'v_Bakery_by',
-                    vars = { creator.name }
-                }
+                if Bakery_API.contributors[blind.artist] then
+                    local creator = Bakery_API.contributors[blind.artist]
+                    self.loc_debuff_lines[#self.loc_debuff_lines + 1] = localize {
+                        type = 'variable',
+                        key = 'v_Bakery_by',
+                        vars = { creator.name }
+                    }
                 return
+                end
             end
             if blind.artist then
-                local artist = Bakery_API.contributors[blind.artist]
-                self.loc_debuff_lines[#self.loc_debuff_lines + 1] = localize {
-                    type = 'variable',
-                    key = 'v_Bakery_artist',
-                    vars = { artist.name }
-                }
+                if Bakery_API.contributors[blind.artist] then
+                    local artist = Bakery_API.contributors[blind.artist]
+                    self.loc_debuff_lines[#self.loc_debuff_lines + 1] = localize {
+                        type = 'variable',
+                        key = 'v_Bakery_artist',
+                        vars = { artist.name }
+                    }
+                end
             end
             if blind.coder then
-                local coder = Bakery_API.contributors[blind.coder]
-                self.loc_debuff_lines[#self.loc_debuff_lines + 1] = localize {
-                    type = 'variable',
-                    key = 'v_Bakery_coder',
-                    vars = { coder.name }
-                }
+                if Bakery_API.contributors[blind.coder] then
+                    local coder = Bakery_API.contributors[blind.coder]
+                    self.loc_debuff_lines[#self.loc_debuff_lines + 1] = localize {
+                        type = 'variable',
+                        key = 'v_Bakery_coder',
+                        vars = { coder.name }
+                    }
+                end
             end
             if blind.idea then
-                local idea = Bakery_API.contributors[blind.idea]
-                self.loc_debuff_lines[#self.loc_debuff_lines + 1] = localize {
-                    type = 'variable',
-                    key = 'v_Bakery_idea',
-                    vars = { idea.name }
-                }
+                if Bakery_API.contributors[blind.idea] then
+                    local idea = Bakery_API.contributors[blind.idea]
+                    self.loc_debuff_lines[#self.loc_debuff_lines + 1] = localize {
+                        type = 'variable',
+                        key = 'v_Bakery_idea',
+                        vars = { idea.name }
+                    }
+                end
             end
         end
     end


### PR DESCRIPTION
Blind:set_text assumes that blind.artist is of Bakery format, but other modded blinds can also have an artist tag (ex. Pokermon). Checks to see if the artist etc is actually listed in Bakery_API.contributors to avoid crash at "vars = {creator.name}".