### PR TITLE
Fixing Up Tag trigger

### DIFF
--- a/src/util.lua
+++ b/src/util.lua
@@ -720,19 +720,16 @@ Bakery_API.guard(function()
 
     local raw_SMODS_calculate_repetitions = SMODS.calculate_repetitions
     SMODS.calculate_repetitions = function(card, context, reps, ...)
-        reps = raw_SMODS_calculate_repetitions(card, context, reps, ...)
-
         for i = 1, #G.GAME.tags do
             local eval = G.GAME.tags[i]:apply_to_run({
                 type = 'Bakery_add_repetitions_to_card',
                 context = context
             })
             if eval then
-                SMODS.insert_repetitions(reps, eval, G.GAME.tags[i])
+                reps[#reps + 1] = { key = eval }
             end
         end
-
-        return reps
+        return raw_SMODS_calculate_repetitions(card, context, reps, ...)
     end
 
     sendInfoMessage("SMODS.calculate_repetitions() patched. Reason: Up Tag", "Bakery")


### PR DESCRIPTION
For some reason:
```src/util.lua:reps = raw_SMODS_calculate_repetitions(card, context, reps, ...) ```
does not appear to form a non-null value for reps, which is then passed to:
```SMODS.insert_repetitions(reps, etc)```
and eventually collides in SMODS/_/src/utils.lua at:
```SMODS.insert_repetitions(ret, etc```
where ret is expected to be a table.

By fixing raw_SMODS_calculate_repetitions we can have it pass on each additional "Up Tag" repetition into the reps table to a return. Used some code from the mod Paperback (utilities/hooks.lua:calculate_repetitions_ref) as a guideline while fixing this.

After commit 0458cd5
<img width="525" height="119" alt="image" src="https://github.com/user-attachments/assets/2812f8a1-4da6-4889-b208-0b85dd07c449" />