### PR TITLE
Icon.png casing in manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
     "description": "Some miscellaneous additions:\n\nAdds Charms, Tags, Jokers, Blinds, and much more.",
     "prefix": "Bakery",
     "main_file": "src/main.lua",
-    "icon_path": "icon.png",
+    "icon_path": "Icon.png",
     "priority": 0,
     "badge_colour": "EDD198",
     "badge_text_colour": "362708",

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
     "badge_colour": "EDD198",
     "badge_text_colour": "362708",
     "display_name": "Bakery",
-    "version": "3.1.2",
+    "version": "3.1.3",
     "dependencies": [
         "Steamodded (>=1.0.0~BETA-0711a)",
         "Lovely (>=0.6)"


### PR DESCRIPTION
prevents issue with SMODS failing to find `mod.path.."/assets/1x/"..mod.icon_path` in SMODS src/preflight/loader.lua (which thusly leads to trying to load image data that doesn't exist, and crashing)


my enviro I'm testing on is currently steamdeck (linux), just as a guess it might be that the casing was ignored on other file systems? who knows